### PR TITLE
Changing meteor's auth URL to the one that supports login with GitHub

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -21,7 +21,7 @@ class MeteorAuthenticator < ::Auth::OAuth2Authenticator
                       :client_secret => GlobalSetting.try(:meteor_client_secret),
                       :provider_ignores_state => true,
                       :client_options => {
-                        :site => 'https://www.meteor.com',
+                        :site => 'https://accounts.meteor.com',
                         :authorize_url => '/oauth2/authorize',
                         :token_url => '/oauth2/token'
                       }
@@ -32,7 +32,7 @@ class MeteorAuthenticator < ::Auth::OAuth2Authenticator
     token = URI.escape(auth['credentials']['token'])
     token.gsub!(/\+/, '%2B')
 
-    user = JSON.parse(open("https://www.meteor.com/api/v1/identity", { "Authorization" => "Bearer #{token}" }).read)
+    user = JSON.parse(open("https://accounts.meteor.com/api/v1/identity", { "Authorization" => "Bearer #{token}" }).read)
 
     result.username = user['username']
     if user['emails'].present?


### PR DESCRIPTION
Today, the URL www.meteor.com fails when someone tries to log in using their GitHub account.

That happens because the authentication app created for Meteor on GitHub is set up to redirect to accounts.meteor.com when the authentication is completed, so any URL different from this won't work.

This PR fixes this by changing the auth URL from www.meteor.com to account.meteor.com.