### PR TITLE
SECURITY: OAuth callback disables state validation

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -25,7 +25,6 @@ class MeteorAuthenticator < ::Auth::Authenticator
       name: "meteor",
       client_id: GlobalSetting.try(:meteor_client_id),
       client_secret: GlobalSetting.try(:meteor_client_secret),
-      provider_ignores_state: true,
       client_options: {
         site: "https://accounts.meteor.com",
         authorize_url: "/oauth2/authorize",

--- a/spec/integration/meteor_omniauth_spec.rb
+++ b/spec/integration/meteor_omniauth_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+RSpec.describe "Meteor OAuth2" do
+  let(:access_token) { "meteor_access_token_448" }
+  let(:client_id) { "abcdef11223344" }
+  let(:client_secret) { "adddcccdddd99922" }
+  let(:temp_code) { "meteor_temp_code_544254" }
+
+  fab!(:user)
+
+  before do
+    GlobalSetting.stubs(:meteor_client_id).returns(client_id)
+    GlobalSetting.stubs(:meteor_client_secret).returns(client_secret)
+
+    stub_request(:post, "https://accounts.meteor.com/oauth2/token").to_return(
+      status: 200,
+      body: Rack::Utils.build_query(access_token: access_token, token_type: "bearer"),
+      headers: {
+        "Content-Type" => "application/x-www-form-urlencoded",
+      },
+    )
+
+    stub_request(:get, "https://accounts.meteor.com/api/v1/identity").with(
+      headers: {
+        "Authorization" => "Bearer #{access_token}",
+      },
+    ).to_return(
+      status: 200,
+      body:
+        JSON.dump(
+          id: "meteor-user-id",
+          username: "meteor-user",
+          emails: [{ address: user.email, primary: true, verified: true }],
+        ),
+      headers: {
+        "Content-Type" => "application/json",
+      },
+    )
+  end
+
+  it "rejects callbacks with missing or mismatched state before fetching the Meteor identity" do
+    [nil, "mismatched-state"].each do |state|
+      post "/auth/meteor"
+      expect(response.status).to eq(302)
+      expect(response.location).to start_with("https://accounts.meteor.com/oauth2/authorize")
+
+      params = { code: temp_code }
+      params[:state] = state if state
+
+      post "/auth/meteor/callback", params: params
+
+      expect(response.status).to eq(302)
+      expect(response.location).to include("/auth/failure?message=csrf_detected")
+      expect(session[:current_user_id]).to be_blank
+    end
+
+    expect(WebMock).not_to have_requested(:get, "https://accounts.meteor.com/api/v1/identity")
+  end
+end


### PR DESCRIPTION
## Summary

Prevent CSRF attacks during Meteor OAuth authentication by enabling standard state validation. The Meteor OAuth2 provider no longer ignores the state parameter, ensuring that authentication callbacks are verified against the initiating session before proceeding.

## Source

- Patch Triage: https://patch.discourse.org/patch-triage/1413

Co-authored-by: discourse-patch-triage <272280883+discourse-patch-triage[bot]@users.noreply.github.com>